### PR TITLE
All "anyURI" links go outside

### DIFF
--- a/config/src/main/java/org/edmcouncil/spec/fibo/config/configuration/loader/saxparser/WeaselConfigurationHandler.java
+++ b/config/src/main/java/org/edmcouncil/spec/fibo/config/configuration/loader/saxparser/WeaselConfigurationHandler.java
@@ -1,9 +1,6 @@
 package org.edmcouncil.spec.fibo.config.configuration.loader.saxparser;
 
-import java.util.LinkedHashSet;
-import java.util.Set;
 import org.edmcouncil.spec.fibo.config.configuration.model.ConfigElement;
-import org.edmcouncil.spec.fibo.config.configuration.model.ConfigElementType;
 import org.edmcouncil.spec.fibo.config.configuration.model.Configuration;
 import org.edmcouncil.spec.fibo.config.configuration.model.GroupType;
 import org.edmcouncil.spec.fibo.config.configuration.model.WeaselConfigKeys;
@@ -39,7 +36,9 @@ public class WeaselConfigurationHandler extends DefaultHandler {
 
     switch (qName) {
       case WeaselConfigKeys.PRIORITY_LIST:
-      case WeaselConfigKeys.IGNORED_TO_DISPLAY:
+      case WeaselConfigKeys.IGNORE_TO_DISPLAYING:
+      case WeaselConfigKeys.IGNORE_TO_LINKING:
+      case WeaselConfigKeys.SCOPE_IRI:
       case WeaselConfigKeys.GROUPS:
       case WeaselConfigKeys.RENAME_GROUPS:
         this.key = qName;
@@ -60,7 +59,8 @@ public class WeaselConfigurationHandler extends DefaultHandler {
 
     switch (qName) {
       case WeaselConfigKeys.PRIORITY_LIST_ELEMENT:
-      case WeaselConfigKeys.IGNORED_TO_DISPLAY_ELEMENT:
+      case WeaselConfigKeys.IGNORED_ELEMENT:
+      case WeaselConfigKeys.URI_NAMESPACE:
         if (!val.trim().isEmpty()) {
           ConfigElement configEl = new ConfigStringElement(val);
 

--- a/config/src/main/java/org/edmcouncil/spec/fibo/config/configuration/model/WeaselConfigKeys.java
+++ b/config/src/main/java/org/edmcouncil/spec/fibo/config/configuration/model/WeaselConfigKeys.java
@@ -7,8 +7,9 @@ public class WeaselConfigKeys {
 
   public static final String PRIORITY_LIST = "priorityList";
   public static final String PRIORITY_LIST_ELEMENT = "priority";
-  public static final String IGNORED_TO_DISPLAY = "ignoredToDisplay";
-  public static final String IGNORED_TO_DISPLAY_ELEMENT = "ignore";
+  public static final String IGNORE_TO_DISPLAYING = "ignoreToDisplaying";
+  public static final String IGNORE_TO_LINKING = "ignoreToLinking";
+  public static final String IGNORED_ELEMENT = "ignore";
   public static final String GROUPS = "groups";
   public static final String GROUP = "group";
   public static final String GROUP_NAME = "groupName";
@@ -18,4 +19,6 @@ public class WeaselConfigKeys {
   public static final String RENAME = "rename";
   public static final String OLD_NAME = "oldName";
   public static final String NEW_NAME = "newName";
+  public static final String SCOPE_IRI = "scopeIri";
+  public static final String URI_NAMESPACE = "uriNamespace";
 }

--- a/config/src/main/java/org/edmcouncil/spec/fibo/config/configuration/model/impl/WeaselConfiguration.java
+++ b/config/src/main/java/org/edmcouncil/spec/fibo/config/configuration/model/impl/WeaselConfiguration.java
@@ -2,7 +2,6 @@ package org.edmcouncil.spec.fibo.config.configuration.model.impl;
 
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -16,6 +15,10 @@ import org.edmcouncil.spec.fibo.config.configuration.model.WeaselConfigKeys;
 public class WeaselConfiguration implements Configuration<Set<ConfigElement>> {
 
   private Map<String, Set<ConfigElement>> configuration;
+
+  public WeaselConfiguration() {
+    configuration = new HashMap<>();
+  }
 
   @Override
   public Map<String, Set<ConfigElement>> getConfiguration() {
@@ -73,6 +76,23 @@ public class WeaselConfiguration implements Configuration<Set<ConfigElement>> {
     }
 
     return null;
+  }
+
+  //TODO: Change this method name..
+  /**
+   *
+   * @param uri - String representation of URI
+   * @return True if it finds representation in the configuration, otherwise false.
+   */
+  public Boolean isUriIri(String uri) {
+    Set<ConfigElement> scopeIri = configuration.getOrDefault(WeaselConfigKeys.SCOPE_IRI, new HashSet<>());
+    for (ConfigElement configElement : scopeIri) {
+      ConfigStringElement element = (ConfigStringElement) configElement;
+      if (uri.contains(element.toString())) {
+        return Boolean.TRUE;
+      }
+    }
+    return Boolean.FALSE;
   }
 
 }

--- a/view/src/main/java/org/edmcouncil/spec/fibo/view/util/custom/jsp/tag/PropertyRenderTag.java
+++ b/view/src/main/java/org/edmcouncil/spec/fibo/view/util/custom/jsp/tag/PropertyRenderTag.java
@@ -5,7 +5,6 @@ import org.edmcouncil.spec.fibo.weasel.model.property.OwlAnnotationPropertyValue
 import org.edmcouncil.spec.fibo.weasel.model.property.OwlAxiomPropertyValue;
 import java.io.IOException;
 import java.util.Map;
-import java.util.regex.Pattern;
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.JspWriter;
 import javax.servlet.jsp.tagext.SimpleTagSupport;
@@ -42,7 +41,7 @@ public class PropertyRenderTag extends SimpleTagSupport {
 
   @Override
   public void doTag()
-      throws JspException, IOException {
+          throws JspException, IOException {
 
     switch (property.getType()) {
       case STRING:
@@ -158,7 +157,8 @@ public class PropertyRenderTag extends SimpleTagSupport {
 
   private String parseSearchPath(String link, String val) {
     String result;
-    result = String.format(URL_SEARCH_QUERY_PATTERN, searchPath, link, val);
+    String tmpSearchPath = searchPath.equals("*") ? "" : searchPath;
+    result = String.format(URL_SEARCH_QUERY_PATTERN, tmpSearchPath, link, val);
     return result;
   }
 

--- a/view/src/main/java/org/edmcouncil/spec/fibo/view/util/custom/jsp/tag/TaxonomyElementRenderTag.java
+++ b/view/src/main/java/org/edmcouncil/spec/fibo/view/util/custom/jsp/tag/TaxonomyElementRenderTag.java
@@ -75,7 +75,8 @@ public class TaxonomyElementRenderTag extends SimpleTagSupport {
 
   private String parseSearchPath(String link, String val) {
     String result;
-    result = String.format(URL_SEARCH_QUERY_PATTERN, searchPath, link, val);
+    String tmpSearchPath = searchPath.equals("*") ? "" : searchPath;
+    result = String.format(URL_SEARCH_QUERY_PATTERN, tmpSearchPath, link, val);
     return result;
   }
 

--- a/view/src/main/webapp/WEB-INF/jsp/page/elements/viewGrouped.jsp
+++ b/view/src/main/webapp/WEB-INF/jsp/page/elements/viewGrouped.jsp
@@ -1,5 +1,5 @@
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions"%>
-<c:set var = "context" value = "http://localhost:8080"/>
+<c:set var = "context" value = "*"/>
 
 <c:forEach items="${details_list}" var="clazz">
   <div class="my-3 px-3">

--- a/weasel/src/main/java/org/edmcouncil/spec/fibo/weasel/ontology/WeaselOntologyManager.java
+++ b/weasel/src/main/java/org/edmcouncil/spec/fibo/weasel/ontology/WeaselOntologyManager.java
@@ -79,7 +79,9 @@ public class WeaselOntologyManager {
     ontology = o;
 
   }
-
+  /**
+   *  
+   */
   private Set<OWLOntology> openOntologiesFromDirectory(File ontologiesDir, OWLOntologyManager manager) throws OWLOntologyCreationException {
     Set<OWLOntology> result = new HashSet<>();
     for (File file : ontologiesDir.listFiles()) {

--- a/weasel_config.xml
+++ b/weasel_config.xml
@@ -1,14 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <properties>
 
+   
+  <filter><!--Here we place the definition of all filters used in the program-->
+   
+    <!--Feature will be added if future-->
+    <ignoreToDisplaying>
+      <ignore>http://www.some.iri#ignoreToDisplaying</ignore>
+    </ignoreToDisplaying>
+       
+    <!--Feature will be added if future-->
+    <ignoreToLinking>
+      <ignore>http://www.some.iri#ignoreToLinking</ignore>
+    </ignoreToLinking>
+       
+    <!-- Here we define URIs to be treated as IRIs -->
+    <!-- We are currently using the method contains(), please be careful when define URIs -->
+    <scopeIri>
+      <uriNamespace>https://spec.edmcouncil.org/fibo/ontology</uriNamespace>
+      <uriNamespace>https://www.omg.org/spec/</uriNamespace>
+    </scopeIri>
+       
+  </filter>
+
   <priorityList><!--This list will be used when groups is not present-->
     <priority>http://www.w3.org/2000/01/rdf-schema#subClassOf</priority>
     <priority>http://www.w3.org/2000/01/rdf-schema#seeAlso</priority>
   </priorityList>
-	
-  <ignoredToDisplay><!--Feature will be added if future-->
-    <ignore>http://www.some.iri#ignoredToDisplay</ignore>
-  </ignoredToDisplay>
+
 	
   <groups><!--The order of elements in groups will be their priority-->
     <group>


### PR DESCRIPTION
> All "anyURI" links go outside. The ones containing "https://spec.edmcouncil.org/fibo/ontology" should be displayed by FIBO viewer. See depends on links e.g. here:
> 
> http://localhost:8080/search?query=https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/

Fixed displaying anyURI links. Each URI defined in the configuration in the appropriate tags will be treated as IRI.