### PR TITLE
http://www.w3.org/2004/02/skos/core#definition is used in FIBO to pro…

### DIFF
--- a/web-app/fibo_viewer_config.xml
+++ b/web-app/fibo_viewer_config.xml
@@ -154,7 +154,11 @@
         <resourceIriToName>http://purl.org/dc/terms/contributor</resourceIriToName>
         <resourceIriName>contributor</resourceIriName>
       </userDefinedName>
-      
+
+      <userDefinedName>
+        <resourceIriToName>http://www.w3.org/2004/02/skos/core#definition</resourceIriToName>
+        <resourceIriName>definiens</resourceIriName>
+      </userDefinedName>      
   
     </userDefaultNameList>
     


### PR DESCRIPTION
…vide definiens that defines the definiendum in a definition. So I propose the following resourceIriName for skos:definition in the config file:

      <userDefinedName>
        <resourceIriToName>http://www.w3.org/2004/02/skos/core#definition</resourceIriToName>
        <resourceIriName>definiens</resourceIriName>
      </userDefinedName>